### PR TITLE
optimize drag handler

### DIFF
--- a/src/matcher/machine.ts
+++ b/src/matcher/machine.ts
@@ -268,6 +268,12 @@ export class MatcherMachine {
             on: {
               mousemove: {
                 actions: 'mergeStep',
+                cond: ({ currentStep }) =>
+                  !!currentStep &&
+                  !currentStep.events.some(
+                    (event) =>
+                      event.type === 'mouseup' || event.type === 'dragend',
+                  ),
               },
               mouseup: {
                 actions: 'mergeStep',
@@ -288,6 +294,9 @@ export class MatcherMachine {
                 actions: 'mergeStep',
               },
               dragover: {
+                actions: 'mergeStep',
+              },
+              dragend: {
                 actions: 'mergeStep',
               },
               drop: {


### PR DESCRIPTION
1. not to record extra mousemove event in drag event when mouseup or drop occur.
2. handle dragend event.