### PR TITLE
optimize type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 export * from './builtin';
-export * from './observers';
+export * from './observer';
 export * from './types';
 export * from './matcher';
 export * from './recorder';

--- a/src/matcher/types.ts
+++ b/src/matcher/types.ts
@@ -1,38 +1,40 @@
 import { StateSchema } from 'xstate';
 import {
-  AuxClickEvent,
-  MachineBeforeUnloadEvent,
-  MachineWheelEvent,
-  BlurEvent,
-  BrowseFileEvent,
-  ClickEvent,
-  DblClickEvent,
-  DragEndEvent,
-  DragEnterEvent,
-  DraggingEvent,
-  DragLeaveEvent,
-  DragOverEvent,
-  DragStartEvent,
-  DropEvent,
-  HoverEvent,
-  KeydownEvent,
-  KeypressEvent,
-  KeyupEvent,
-  MousedownEvent,
-  MousemoveEvent,
-  MouseupEvent,
-  ScrollEvent,
-  TextChangeEvent,
-  TextInputEvent,
+  BaseAuxClickEvent,
+  BaseBeforeUnloadEvent,
+  BaseWheelEvent,
+  BaseBlurEvent,
+  BaseBrowseFileEvent,
+  BaseClickEvent,
+  BaseDblClickEvent,
+  BaseDragEndEvent,
+  BaseDragEnterEvent,
+  BaseDragLeaveEvent,
+  BaseDragOverEvent,
+  BaseDragStartEvent,
+  BaseDropEvent,
+  BaseHoverEvent,
+  BaseKeydownEvent,
+  BaseKeypressEvent,
+  BaseKeyupEvent,
+  BaseMousedownEvent,
+  BaseMousemoveEvent,
+  BaseMouseupEvent,
+  BaseScrollEvent,
+  BaseTextChangeEvent,
+  BaseTextInputEvent,
   Step,
-  StepEvent,
-  MachineLoadEvent,
-  MachineResizeEvent,
+  BaseStepEvent,
+  BaseLoadEvent,
+  BaseResizeEvent,
+  BaseDragEvent,
 } from '../types';
 
-export interface MatcherContext {
-  currentStep?: MatcherStep;
-  previousStep?: MatcherStep;
+export interface MatcherContext<
+  TStepEvent extends BaseStepEvent = BaseStepEvent,
+> {
+  currentStep?: MatcherStep<TStepEvent>;
+  previousStep?: MatcherStep<TStepEvent>;
 }
 /* eslint-disable @typescript-eslint/ban-types */
 export interface MatcherSchema extends StateSchema {
@@ -56,101 +58,134 @@ export interface MatcherSchema extends StateSchema {
 }
 /* eslint-enable @typescript-eslint/ban-types */
 export type MatcherEvent =
-  | { type: 'mousedown'; data: MousedownEvent; target: MatcherElement | null }
-  | { type: 'mouseup'; data: MouseupEvent; target: MatcherElement | null }
-  | { type: 'click'; data: ClickEvent; target: MatcherElement | null }
-  | { type: 'dblclick'; data: DblClickEvent; target: MatcherElement | null }
-  | { type: 'auxclick'; data: AuxClickEvent; target: MatcherElement | null }
-  | { type: 'mousemove'; data: MousemoveEvent; target: MatcherElement | null }
-  | { type: 'scroll'; data: ScrollEvent; target: MatcherElement | null }
-  | { type: 'keydown'; data: KeydownEvent; target: MatcherElement | null }
-  | { type: 'keypress'; data: KeypressEvent; target: MatcherElement | null }
-  | { type: 'keyup'; data: KeyupEvent; target: MatcherElement | null }
-  | { type: 'text_input'; data: TextInputEvent; target: MatcherElement | null }
+  | {
+      type: 'mousedown';
+      data: BaseMousedownEvent;
+      target: MatcherElement | null;
+    }
+  | { type: 'mouseup'; data: BaseMouseupEvent; target: MatcherElement | null }
+  | { type: 'click'; data: BaseClickEvent; target: MatcherElement | null }
+  | { type: 'dblclick'; data: BaseDblClickEvent; target: MatcherElement | null }
+  | { type: 'auxclick'; data: BaseAuxClickEvent; target: MatcherElement | null }
+  | {
+      type: 'mousemove';
+      data: BaseMousemoveEvent;
+      target: MatcherElement | null;
+    }
+  | { type: 'scroll'; data: BaseScrollEvent; target: MatcherElement | null }
+  | { type: 'keydown'; data: BaseKeydownEvent; target: MatcherElement | null }
+  | { type: 'keypress'; data: BaseKeypressEvent; target: MatcherElement | null }
+  | { type: 'keyup'; data: BaseKeyupEvent; target: MatcherElement | null }
+  | {
+      type: 'text_input';
+      data: BaseTextInputEvent;
+      target: MatcherElement | null;
+    }
   | {
       type: 'text_change';
-      data: TextChangeEvent;
+      data: BaseTextChangeEvent;
       target: MatcherElement | null;
     }
-  | { type: 'blur'; data: BlurEvent; target: MatcherElement | null }
-  | { type: 'load'; data: MachineLoadEvent; target: MatcherElement | null }
+  | { type: 'blur'; data: BaseBlurEvent; target: MatcherElement | null }
+  | { type: 'load'; data: BaseLoadEvent; target: MatcherElement | null }
   | {
       type: 'before_unload';
-      data: MachineBeforeUnloadEvent;
+      data: BaseBeforeUnloadEvent;
       target: MatcherElement | null;
     }
-  | { type: 'hover'; data: HoverEvent; target: MatcherElement | null }
-  | { type: 'wheel'; data: MachineWheelEvent; target: MatcherElement | null }
-  | { type: 'drag'; data: DraggingEvent; target: MatcherElement | null }
-  | { type: 'dragstart'; data: DragStartEvent; target: MatcherElement | null }
-  | { type: 'dragend'; data: DragEndEvent; target: MatcherElement | null }
-  | { type: 'dragenter'; data: DragEnterEvent; target: MatcherElement | null }
-  | { type: 'dragover'; data: DragOverEvent; target: MatcherElement | null }
-  | { type: 'dragleave'; data: DragLeaveEvent; target: MatcherElement | null }
-  | { type: 'drop'; data: DropEvent; target: MatcherElement | null }
-  | { type: 'file'; data: BrowseFileEvent; target: MatcherElement | null }
-  | { type: 'resize'; data: MachineResizeEvent; target: MatcherElement | null };
+  | { type: 'hover'; data: BaseHoverEvent; target: MatcherElement | null }
+  | { type: 'wheel'; data: BaseWheelEvent; target: MatcherElement | null }
+  | { type: 'drag'; data: BaseDragEvent; target: MatcherElement | null }
+  | {
+      type: 'dragstart';
+      data: BaseDragStartEvent<unknown>;
+      target: MatcherElement | null;
+    }
+  | { type: 'dragend'; data: BaseDragEndEvent; target: MatcherElement | null }
+  | {
+      type: 'dragenter';
+      data: BaseDragEnterEvent;
+      target: MatcherElement | null;
+    }
+  | { type: 'dragover'; data: BaseDragOverEvent; target: MatcherElement | null }
+  | {
+      type: 'dragleave';
+      data: BaseDragLeaveEvent;
+      target: MatcherElement | null;
+    }
+  | {
+      type: 'drop';
+      data: BaseDropEvent<unknown>;
+      target: MatcherElement | null;
+    }
+  | {
+      type: 'file';
+      data: BaseBrowseFileEvent<unknown>;
+      target: MatcherElement | null;
+    }
+  | { type: 'resize'; data: BaseResizeEvent; target: MatcherElement | null };
 
-export type MatcherState =
+export type MatcherState<TStepEvent extends BaseStepEvent = BaseStepEvent> =
   | {
       value: 'INIT';
-      context: MatcherContext;
+      context: MatcherContext<TStepEvent>;
     }
   | {
       value: 'CLICK';
-      context: MatcherContext;
+      context: MatcherContext<TStepEvent>;
     }
   | {
       value: 'RIGHT_CLICK';
-      context: MatcherContext;
+      context: MatcherContext<TStepEvent>;
     }
   | {
       value: 'DBLCLICK';
-      context: MatcherContext;
+      context: MatcherContext<TStepEvent>;
     }
   | {
       value: 'DRAG';
-      context: MatcherContext;
+      context: MatcherContext<TStepEvent>;
     }
   | {
       value: 'KEYPRESS';
-      context: MatcherContext;
+      context: MatcherContext<TStepEvent>;
     }
   | {
       value: 'TEXT';
-      context: MatcherContext;
+      context: MatcherContext<TStepEvent>;
     }
   | {
       value: 'BROWSE_FILE';
-      context: MatcherContext;
+      context: MatcherContext<TStepEvent>;
     }
   | {
       value: 'NAVIGATION';
-      context: MatcherContext;
+      context: MatcherContext<TStepEvent>;
     }
   | {
       value: 'SCROLL';
-      context: MatcherContext;
+      context: MatcherContext<TStepEvent>;
     }
   | {
       value: 'REFRESH';
-      context: MatcherContext;
+      context: MatcherContext<TStepEvent>;
     }
   | {
       value: 'RESIZE';
-      context: MatcherContext;
+      context: MatcherContext<TStepEvent>;
     }
   | {
       value: 'UNKNOWN';
-      context: MatcherContext;
+      context: MatcherContext<TStepEvent>;
     };
 
-export type MatcherStep = Omit<Step, 'selector'> & {
-  // main target, usually the only event target of interaction
-  target: MatcherElement | null;
-  // secondary target, like drop source;
-  secondary_target: MatcherElement[];
-};
+export type MatcherStep<TStepEvent extends BaseStepEvent = BaseStepEvent> =
+  Omit<Step<TStepEvent>, 'selector'> & {
+    // main target, usually the only event target of interaction
+    target: MatcherElement | null;
+    // secondary target, like drop source;
+    secondary_target: MatcherElement[];
+  };
 
 export type MatcherElement = {
   id: string;
@@ -158,11 +193,14 @@ export type MatcherElement = {
   attributes: Record<string, string>;
 };
 
-export type MachineMatcherInput = {
+export type MachineMatcherInput<TStepEvent extends BaseStepEvent> = {
   element: MatcherElement | null;
-  event: StepEvent;
+  event: TStepEvent;
 };
 
 export type emitType = 'new' | 'end' | 'update';
 
-export type emitFn = (type: emitType, step: MatcherStep) => void;
+export type emitFn<TStepEvent extends BaseStepEvent> = (
+  type: emitType,
+  step: MatcherStep<TStepEvent>,
+) => void;

--- a/src/observer/abstractObserver.ts
+++ b/src/observer/abstractObserver.ts
@@ -1,0 +1,44 @@
+import { ThrottleManager } from '../util/throttler';
+import { EventEmitter2 } from 'eventemitter2';
+import { EventProcessor, IObserver, ObserverListener } from './type';
+
+export abstract class AbstractObserver<TEvent, TOutput>
+  implements IObserver<TOutput>
+{
+  abstract name: string;
+  abstract emitter: EventEmitter2;
+
+  abstract start(): void;
+  abstract stop(): void;
+  abstract suspend(): void;
+
+  private static throttleManager = new ThrottleManager();
+  protected preprocess: EventProcessor<TEvent, TOutput>;
+  protected getThrottler: typeof ThrottleManager.prototype.getThrottle;
+  protected invokeAll: typeof ThrottleManager.prototype.invokeAll;
+
+  constructor(preprocess: EventProcessor<TEvent, TOutput>) {
+    this.getThrottler = (...args) => {
+      return AbstractObserver.throttleManager.getThrottle(...args);
+    };
+
+    this.invokeAll = () => {
+      return AbstractObserver.throttleManager.invokeAll();
+    };
+    this.preprocess = preprocess;
+  }
+
+  protected onEmit(event: TEvent, args: any[], fromThrottler = false) {
+    !fromThrottler && AbstractObserver.throttleManager.invokeAll();
+    this.emitter.emit(`observer.${this.name}`, this.preprocess(event, ...args));
+  }
+
+  public on(listener: ObserverListener<TOutput>): ObserverListener<TOutput> {
+    this.emitter.on(`observer.${this.name}`, listener);
+    return listener;
+  }
+
+  public off(listener: ObserverListener<TOutput>): void {
+    this.emitter.off(`observer.${this.name}`, listener);
+  }
+}

--- a/src/observer/index.ts
+++ b/src/observer/index.ts
@@ -1,0 +1,3 @@
+export * from './abstractObserver';
+export * from './eventObserver';
+export * from './type';

--- a/src/observer/type.ts
+++ b/src/observer/type.ts
@@ -1,0 +1,171 @@
+import { EventEmitter2 } from 'eventemitter2';
+import {
+  BaseBlurEvent,
+  BaseClickEvent,
+  BaseDblClickEvent,
+  BaseDragEvent,
+  BaseKeydownEvent,
+  BaseMousemoveEvent,
+  BaseTextChangeEvent,
+  BaseTextInputEvent,
+  BaseWheelEvent,
+  BaseAuxClickEvent,
+  BaseBeforeUnloadEvent,
+  BaseDragStartEvent,
+  BaseHoverEvent,
+  BaseKeyboardEvent,
+  BaseKeyupEvent,
+  BaseLoadEvent,
+  BaseMousedownEvent,
+  BaseMouseupEvent,
+  BaseScrollEvent,
+  BaseBrowseFileEvent,
+  BaseDragEndEvent,
+  BaseDragEnterEvent,
+  BaseDragLeaveEvent,
+  BaseDragOverEvent,
+  BaseDropEvent,
+  BaseResizeEvent,
+  Modifiers,
+} from '../types';
+
+// extra mouse event init pick by observer
+interface ExtraMouseEventInit {
+  screenX: number;
+  screenY: number;
+  clientX: number;
+  clientY: number;
+  modifiers: Modifiers;
+}
+
+export interface ObserverMousedownEvent
+  extends BaseMousedownEvent,
+    ExtraMouseEventInit {}
+
+export interface ObserverMouseupEvent
+  extends BaseMouseupEvent,
+    ExtraMouseEventInit {}
+
+export interface ObserverClickEvent
+  extends BaseClickEvent,
+    ExtraMouseEventInit {}
+
+export interface ObserverDblClickEvent
+  extends BaseDblClickEvent,
+    ExtraMouseEventInit {}
+
+export interface ObserverAuxClickEvent
+  extends BaseAuxClickEvent,
+    ExtraMouseEventInit {}
+
+export type ObserverMousemoveEvent = BaseMousemoveEvent;
+export type ObserverScrollEvent = BaseScrollEvent;
+
+interface ExtraKeyboardEventInit {
+  code: string;
+  keyCode: number;
+  modifiers: Modifiers;
+}
+
+export interface ObserverKeydownEvent
+  extends BaseKeydownEvent,
+    ExtraKeyboardEventInit {}
+
+export interface ObserverKeypressEvent
+  extends BaseKeyboardEvent,
+    ExtraKeyboardEventInit {}
+
+export interface ObserverKeyupEvent
+  extends BaseKeyupEvent,
+    ExtraKeyboardEventInit {}
+
+export type ObserverTextInputEvent = BaseTextInputEvent;
+export type ObserverTextChangeEvent = BaseTextChangeEvent;
+export type ObserverLoadEvent = BaseLoadEvent;
+export type ObserverBeforeUnloadEvent = BaseBeforeUnloadEvent;
+export type ObserverBlurEvent = BaseBlurEvent;
+export type ObserverHoverEvent = BaseHoverEvent;
+
+interface ExtraWheelEventInit {
+  deltaMode?: number;
+  deltaX?: number;
+  deltaY?: number;
+  deltaZ?: number;
+}
+
+export interface ObserverWheelEvent
+  extends ExtraWheelEventInit,
+    BaseWheelEvent {}
+
+export interface ObserverDragEvent extends BaseDragEvent, ExtraMouseEventInit {}
+export interface ObserverDragStartEvent
+  extends BaseDragStartEvent<File>,
+    ExtraMouseEventInit {}
+export interface ObserverDragEndEvent
+  extends BaseDragEndEvent,
+    ExtraMouseEventInit {}
+export interface ObserverDragEnterEvent
+  extends BaseDragEnterEvent,
+    ExtraMouseEventInit {}
+export interface ObserverDragOverEvent
+  extends BaseDragOverEvent,
+    ExtraMouseEventInit {}
+export interface ObserverDragLeaveEvent
+  extends BaseDragLeaveEvent,
+    ExtraMouseEventInit {}
+export interface ObserverDropEvent
+  extends BaseDropEvent<File>,
+    ExtraMouseEventInit {}
+export type ObserverBrowseFileEvent = BaseBrowseFileEvent<File>;
+export type ObserverResizeEvent = BaseResizeEvent;
+
+export type EventObserverStepEvent =
+  | ObserverMousedownEvent
+  | ObserverMouseupEvent
+  | ObserverClickEvent
+  | ObserverAuxClickEvent
+  | ObserverDblClickEvent
+  | ObserverMousemoveEvent
+  | ObserverScrollEvent
+  | ObserverKeydownEvent
+  | ObserverKeypressEvent
+  | ObserverKeyupEvent
+  | ObserverTextInputEvent
+  | ObserverTextChangeEvent
+  | ObserverBlurEvent
+  | ObserverLoadEvent
+  | ObserverBeforeUnloadEvent
+  | ObserverHoverEvent
+  | ObserverWheelEvent
+  | ObserverDragEvent
+  | ObserverDragStartEvent
+  | ObserverDragEndEvent
+  | ObserverDragEnterEvent
+  | ObserverDragOverEvent
+  | ObserverDragLeaveEvent
+  | ObserverDropEvent
+  | ObserverBrowseFileEvent
+  | ObserverResizeEvent;
+
+declare global {
+  interface UIEvent {
+    path: Array<HTMLElement>;
+  }
+}
+
+export interface IObserver<TOutput> {
+  name: string;
+  emitter: EventEmitter2;
+  start(): void;
+  stop(): void;
+  suspend(): void;
+  on(listenerFn: ObserverListener<TOutput>): ObserverListener<TOutput>;
+  off(listenerFn: ObserverListener<TOutput>): void;
+}
+
+export type ObserverListener<TOutput> = (output: TOutput) => void;
+
+export type EventProcessor<TEvent, TOutput> = (
+  event: TEvent,
+  ...args: any[]
+) => TOutput;

--- a/src/recorder/index.ts
+++ b/src/recorder/index.ts
@@ -1,6 +1,6 @@
-﻿import { IMatcher } from './matcher';
-import { AbstractObserver } from './observers';
-import { MatcherKey } from './types';
+﻿import { IMatcher } from '../matcher';
+import { AbstractObserver } from '../observer';
+import { MatcherKey } from '../types';
 
 export type RecorderOptions<TMiddleware> = {
   matcher: IMatcher<TMiddleware>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,7 +8,7 @@ export enum MatcherKey {
   EMIT_END_STEP = 'matcher.step_event.end',
 }
 
-export type Step = {
+export type Step<TEvent extends BaseStepEvent> = {
   selector: IMeta;
   type:
     | 'CLICK'
@@ -25,31 +25,40 @@ export type Step = {
     | 'RESIZE'
     | 'HOVER'
     | 'UNKNOWN';
-  events: StepEvent[];
+  events: TEvent[];
 };
 
-export type StepEvent =
-  | MouseEvents
-  | ScrollEvent
-  | KeydownEvent
-  | KeypressEvent
-  | TextInputEvent
-  | TextChangeEvent
-  | KeyupEvent
-  | BlurEvent
-  | MachineLoadEvent
-  | MachineBeforeUnloadEvent
-  | HoverEvent
-  | MachineWheelEvent
-  | DraggingEvent
-  | DropEvent
-  | DragStartEvent
-  | DragEndEvent
-  | DragEnterEvent
-  | DragOverEvent
-  | DragLeaveEvent
-  | BrowseFileEvent
-  | MachineResizeEvent;
+/**
+ * BaseStepEvent contains the basic info an observer need to get and an matcher need to know
+ */
+
+export type BaseStepEvent =
+  | BaseMousedownEvent
+  | BaseMouseupEvent
+  | BaseClickEvent
+  | BaseAuxClickEvent
+  | BaseDblClickEvent
+  | BaseMousemoveEvent
+  | BaseScrollEvent
+  | BaseKeydownEvent
+  | BaseKeypressEvent
+  | BaseKeyupEvent
+  | BaseTextInputEvent
+  | BaseTextChangeEvent
+  | BaseBlurEvent
+  | BaseLoadEvent
+  | BaseBeforeUnloadEvent
+  | BaseHoverEvent
+  | BaseWheelEvent
+  | BaseDragEvent
+  | BaseDropEvent<unknown>
+  | BaseDragStartEvent<unknown>
+  | BaseDragEndEvent
+  | BaseDragEnterEvent
+  | BaseDragOverEvent
+  | BaseDragLeaveEvent
+  | BaseBrowseFileEvent<unknown>
+  | BaseResizeEvent;
 
 export type Modifiers = {
   // only record modifers when needed
@@ -67,162 +76,198 @@ export type MousemoveRecord = {
   timeOffset: number;
 };
 
-type BaseEvent = {
+interface BaseEvent {
+  type:
+    | 'mousedown'
+    | 'mouseup'
+    | 'mousemove'
+    | 'click'
+    | 'dblclick'
+    | 'auxclick'
+    | 'scroll'
+    | 'keydown'
+    | 'keypress'
+    | 'keyup'
+    | 'text_input'
+    | 'text_change'
+    | 'load'
+    | 'before_unload'
+    | 'blur'
+    | 'hover'
+    | 'wheel'
+    | 'drag'
+    | 'dragstart'
+    | 'dragend'
+    | 'dragenter'
+    | 'dragover'
+    | 'dragleave'
+    | 'drop'
+    | 'file'
+    | 'resize';
   timestamp: number;
-};
-//#region mouse event
-export type MachineMouseEvent = BaseEvent & {
-  // we need to collect mouseEventInit;
-  screenX: number;
-  screenY: number;
-  clientX: number;
-  clientY: number;
+}
+
+export interface BaseMouseEvent extends BaseEvent {
+  // mouseEventInit;
+  type:
+    | 'mousedown'
+    | 'mouseup'
+    | 'click'
+    | 'dblclick'
+    | 'auxclick'
+    | 'drag'
+    | 'drop'
+    | 'dragstart'
+    | 'dragend'
+    | 'dragenter'
+    | 'dragover'
+    | 'dragleave';
   button: number;
   buttons: number;
-  modifiers: Modifiers;
-};
+  clientX: number;
+  clientY: number;
+}
 
-export type MousedownEvent = MachineMouseEvent & {
+export interface BaseMousedownEvent extends BaseMouseEvent {
   type: 'mousedown';
-};
+}
 
-export type MouseupEvent = MachineMouseEvent & {
+export interface BaseMouseupEvent extends BaseMouseEvent {
   type: 'mouseup';
-};
+}
 
-export type ClickEvent = MachineMouseEvent & {
+export interface BaseClickEvent extends BaseMouseEvent {
   type: 'click';
-};
+}
 
-export type DblClickEvent = MachineMouseEvent & {
+export interface BaseDblClickEvent extends BaseMouseEvent {
   type: 'dblclick';
-};
+}
 
-export type AuxClickEvent = MachineMouseEvent & {
+export interface BaseAuxClickEvent extends BaseMouseEvent {
   type: 'auxclick';
-};
+}
 
 // mousemove is special
-export type MousemoveEvent = BaseEvent & {
+export interface BaseMousemoveEvent extends BaseEvent {
   type: 'mousemove';
   positions: Array<MousemoveRecord>;
-};
+}
 
-type MouseEvents =
-  | MousedownEvent
-  | MouseupEvent
-  | ClickEvent
-  | DblClickEvent
-  | AuxClickEvent
-  | MousemoveEvent;
 //#endregion mouse event
 
-export type ScrollEvent = BaseEvent & {
+export interface BaseScrollEvent extends BaseEvent {
   type: 'scroll';
   scrollLeft: number;
   scrollTop: number;
-};
+}
 
 //#region keyboard event
-export type MachineKeyboardEvent = BaseEvent & {
+export interface BaseKeyboardEvent extends BaseEvent {
+  type: 'keydown' | 'keypress' | 'keyup';
   key: string;
-  code: string;
-  keyCode: number;
-  modifiers: Modifiers;
-};
+}
 
-export type KeydownEvent = MachineKeyboardEvent & {
+export interface BaseKeydownEvent extends BaseKeyboardEvent {
   type: 'keydown';
-};
+}
 
-export type KeypressEvent = MachineKeyboardEvent & {
+export interface BaseKeypressEvent extends BaseKeyboardEvent {
   type: 'keypress';
-};
+}
 
-export type KeyupEvent = MachineKeyboardEvent & {
+export interface BaseKeyupEvent extends BaseKeyboardEvent {
   type: 'keyup';
-};
+}
 //#endregion keyboard event
 
 //#region textinput
-export type TextInputEvent = BaseEvent & {
+export interface BaseTextInputEvent extends BaseEvent {
   type: 'text_input';
   data: string;
-  // departed
   value: string;
-};
+}
 
-export type TextChangeEvent = BaseEvent & {
+export interface BaseTextChangeEvent extends BaseEvent {
   type: 'text_change';
   value: string;
-};
+}
 //#endregion textinput
 
-export type MachineLoadEvent = BaseEvent & {
+export interface BaseLoadEvent extends BaseEvent {
   type: 'load';
   url: string;
-};
+}
 
-export type MachineBeforeUnloadEvent = BaseEvent & {
+export interface BaseBeforeUnloadEvent extends BaseEvent {
   type: 'before_unload';
   url: string;
-};
+}
 
-export type BlurEvent = BaseEvent & {
+export interface BaseBlurEvent extends BaseEvent {
   type: 'blur';
-};
+}
 
-export type HoverEvent = BaseEvent & {
+export interface BaseHoverEvent extends BaseEvent {
   type: 'hover';
   clientX: number;
   clientY: number;
-};
+}
 
-export type MachineWheelEvent = BaseEvent & {
+export interface BaseWheelEvent extends BaseEvent {
   type: 'wheel';
-};
+}
 
-export type MachineDragEvent = MachineMouseEvent & {
+export interface BaseDraggingEvent extends BaseMouseEvent {
+  type:
+    | 'drag'
+    | 'dragstart'
+    | 'dragend'
+    | 'dragenter'
+    | 'dragover'
+    | 'dragleave'
+    | 'drop';
   targetIndex: number;
-};
+}
 
 //#region drag
-export type DraggingEvent = MachineDragEvent & {
+export interface BaseDragEvent extends BaseDraggingEvent {
   type: 'drag';
-};
-export type DragStartEvent = MachineDragEvent & {
+}
+export interface BaseDragStartEvent<TFile> extends BaseDraggingEvent {
   type: 'dragstart';
   effectAllowed: DataTransfer['effectAllowed'];
-  items: Array<IDataTransferItem | undefined>;
-};
-export type DragEndEvent = MachineDragEvent & {
+  items: Array<IDataTransferItem<TFile> | undefined>;
+}
+export interface BaseDragEndEvent extends BaseDraggingEvent {
   type: 'dragend';
-};
-export type DragEnterEvent = MachineDragEvent & {
+}
+export interface BaseDragEnterEvent extends BaseDraggingEvent {
   type: 'dragenter';
-};
-export type DragOverEvent = MachineDragEvent & {
+}
+export interface BaseDragOverEvent extends BaseDraggingEvent {
   type: 'dragover';
   dropEffect: DataTransfer['dropEffect'];
-};
-export type DragLeaveEvent = MachineDragEvent & {
+}
+export interface BaseDragLeaveEvent extends BaseDraggingEvent {
   type: 'dragleave';
-};
-export type DropEvent = MachineDragEvent & {
+}
+
+export interface BaseDropEvent<TFile> extends BaseDraggingEvent {
   type: 'drop';
   effectAllowed: DataTransfer['effectAllowed'];
   dropEffect: DataTransfer['dropEffect'];
-  items: Array<IDataTransferItem | undefined>;
-};
+  items: Array<IDataTransferItem<TFile> | undefined>;
+}
 //#endregion drag
 
-export type BrowseFileEvent = BaseEvent & {
+export interface BaseBrowseFileEvent<TFile> extends BaseEvent {
   type: 'file';
-  files: Array<File>;
-};
+  files: Array<TFile>;
+}
 
-export type MachineResizeEvent = BaseEvent & {
+export interface BaseResizeEvent extends BaseEvent {
   type: 'resize';
   x: number;
   y: number;
-};
+}

--- a/src/util/entry-reader.ts
+++ b/src/util/entry-reader.ts
@@ -1,13 +1,15 @@
-export interface IDataTransferFileItem {
+export interface IDataTransferFileItem<TFile> {
   kind: 'file';
   path: string;
-  file: File;
+  file: TFile;
 }
 
-export interface IDataTransferDirectoryItem {
+export interface IDataTransferDirectoryItem<TFile> {
   kind: 'directory';
   path: string;
-  child: Array<IDataTransferFileItem | IDataTransferDirectoryItem | undefined>;
+  child: Array<
+    IDataTransferFileItem<TFile> | IDataTransferDirectoryItem<TFile> | undefined
+  >;
 }
 
 export interface IDataTransferStringItem {
@@ -16,9 +18,9 @@ export interface IDataTransferStringItem {
   type: string;
 }
 
-export type IDataTransferItem =
-  | IDataTransferFileItem
-  | IDataTransferDirectoryItem
+export type IDataTransferItem<TFile> =
+  | IDataTransferFileItem<TFile>
+  | IDataTransferDirectoryItem<TFile>
   | IDataTransferStringItem;
 
 const readDirectoryEntry = async (
@@ -38,7 +40,9 @@ const readFileEntry = async (entry: FileSystemFileEntry): Promise<File> => {
 
 const readEntry = async (
   entry: FileSystemEntry | null,
-): Promise<IDataTransferFileItem | IDataTransferDirectoryItem | undefined> => {
+): Promise<
+  IDataTransferFileItem<File> | IDataTransferDirectoryItem<File> | undefined
+> => {
   if (!entry) {
     return undefined;
   }
@@ -67,12 +71,12 @@ const readEntry = async (
 
 export const getSerializedDataTransferItemList = async (
   dt: DataTransfer | null,
-): Promise<Array<IDataTransferItem | undefined>> => {
+): Promise<Array<IDataTransferItem<File> | undefined>> => {
   if (!dt || !dt.items.length) {
     return [];
   }
   const items = dt.items;
-  const result = new Array<IDataTransferItem | undefined>(items.length);
+  const result = new Array<IDataTransferItem<File> | undefined>(items.length);
   {
     let i = 0;
     for (const item of items) {

--- a/typings/builtin.d.ts
+++ b/typings/builtin.d.ts
@@ -1,11 +1,10 @@
 import { MachineMatcherInput, MatcherElement, MatcherStep } from './matcher/types';
-import { EventObserver } from './observers';
+import { EventObserver, EventObserverStepEvent } from './observer';
 import { Recorder } from './recorder';
-import { StepEvent } from './types';
 export declare type InteractionRecorderOptions = {
-    onNewStep: (step: MatcherStep) => void;
-    onEndStep: (step: MatcherStep) => void;
-    onUpdateStep: (step: MatcherStep) => void;
+    onNewStep: (step: MatcherStep<EventObserverStepEvent>) => void;
+    onEndStep: (step: MatcherStep<EventObserverStepEvent>) => void;
+    onUpdateStep: (step: MatcherStep<EventObserverStepEvent>) => void;
 };
 export declare class ElementSerializer {
     private ElementMap;
@@ -19,9 +18,9 @@ export declare class ElementSerializer {
 export declare class InteractionRecorder {
     private serializer;
     private _observer;
-    get observer(): EventObserver<MachineMatcherInput>;
+    get observer(): EventObserver<MachineMatcherInput<EventObserverStepEvent>>;
     private _recorder;
-    get recorder(): Recorder<StepEvent, MachineMatcherInput>;
+    get recorder(): Recorder<EventObserverStepEvent, MachineMatcherInput<EventObserverStepEvent>>;
     constructor(win: Window, options?: InteractionRecorderOptions);
     start(): void;
     suspend(): void;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,5 +1,5 @@
 export * from './builtin';
-export * from './observers';
+export * from './observer';
 export * from './types';
 export * from './matcher';
 export * from './recorder';

--- a/typings/matcher/index.d.ts
+++ b/typings/matcher/index.d.ts
@@ -1,4 +1,5 @@
 import { EventEmitter2 } from 'eventemitter2';
+import { BaseStepEvent } from '../types';
 import { MatcherMachine } from './machine';
 import { MachineMatcherInput, MatcherStep } from './types';
 export interface IMatcher<TInput> {
@@ -9,22 +10,22 @@ export interface IMatcher<TInput> {
     listen: MatcherListener<TInput>;
 }
 export declare type MatcherListener<TInput> = (input: TInput) => void;
-export declare type MachineMatcherOptions = {
+export declare type MachineMatcherOptions<TStepEvent extends BaseStepEvent = BaseStepEvent> = {
     emitter: EventEmitter2;
-    onNewStep?: (step: MatcherStep) => void;
-    onUpdateStep?: (step: MatcherStep) => void;
-    onEndStep?: (step: MatcherStep) => void;
+    onNewStep?: (step: MatcherStep<TStepEvent>) => void;
+    onUpdateStep?: (step: MatcherStep<TStepEvent>) => void;
+    onEndStep?: (step: MatcherStep<TStepEvent>) => void;
 };
 export * from './types';
-export declare class MachineMatcher implements IMatcher<MachineMatcherInput> {
-    machine: MatcherMachine;
+export declare class MachineMatcher<TStepEvent extends BaseStepEvent = BaseStepEvent> implements IMatcher<MachineMatcherInput<TStepEvent>> {
+    machine: MatcherMachine<TStepEvent>;
     emitter: EventEmitter2;
     private state;
     private handler;
-    constructor(options: MachineMatcherOptions);
+    constructor(options: MachineMatcherOptions<TStepEvent>);
     start(): void;
     suspend(): void;
     stop(): void;
     private emitStep;
-    listen(input: MachineMatcherInput): void;
+    listen(input: MachineMatcherInput<TStepEvent>): void;
 }

--- a/typings/matcher/machine.d.ts
+++ b/typings/matcher/machine.d.ts
@@ -1,12 +1,13 @@
 import { Interpreter, SingleOrArray, Event as XEvent, SCXML, EventData, StateMachine, State } from 'xstate';
 import { MatcherSchema, MatcherEvent, MatcherState, MatcherContext, emitFn } from './types';
-export declare class MatcherMachine {
+import { BaseStepEvent } from '../types';
+export declare class MatcherMachine<TStepEvent extends BaseStepEvent = BaseStepEvent> {
     private _machine;
     private _service;
     private emit;
     private getTargetStateNode;
-    get machine(): StateMachine<MatcherContext, MatcherSchema, MatcherEvent, MatcherState>;
-    get service(): Interpreter<MatcherContext, MatcherSchema, MatcherEvent, MatcherState>;
-    constructor(emit: emitFn);
-    send(event: SingleOrArray<XEvent<MatcherEvent>> | SCXML.Event<MatcherEvent>, payload?: EventData | undefined): State<MatcherContext, MatcherEvent, MatcherSchema, MatcherState>;
+    get machine(): StateMachine<MatcherContext<TStepEvent>, MatcherSchema, MatcherEvent, MatcherState<TStepEvent>>;
+    get service(): Interpreter<MatcherContext<TStepEvent>, MatcherSchema, MatcherEvent, MatcherState<TStepEvent>>;
+    constructor(emit: emitFn<TStepEvent>);
+    send(event: SingleOrArray<XEvent<MatcherEvent>> | SCXML.Event<MatcherEvent>, payload?: EventData | undefined): State<MatcherContext<TStepEvent>, MatcherEvent, MatcherSchema, MatcherState<TStepEvent>>;
 }

--- a/typings/matcher/types.d.ts
+++ b/typings/matcher/types.d.ts
@@ -1,8 +1,8 @@
 import { StateSchema } from 'xstate';
-import { AuxClickEvent, MachineBeforeUnloadEvent, MachineWheelEvent, BlurEvent, BrowseFileEvent, ClickEvent, DblClickEvent, DragEndEvent, DragEnterEvent, DraggingEvent, DragLeaveEvent, DragOverEvent, DragStartEvent, DropEvent, HoverEvent, KeydownEvent, KeypressEvent, KeyupEvent, MousedownEvent, MousemoveEvent, MouseupEvent, ScrollEvent, TextChangeEvent, TextInputEvent, Step, StepEvent } from '../types';
-export interface MatcherContext {
-    currentStep?: MatcherStep;
-    previousStep?: MatcherStep;
+import { BaseAuxClickEvent, BaseBeforeUnloadEvent, BaseWheelEvent, BaseBlurEvent, BaseBrowseFileEvent, BaseClickEvent, BaseDblClickEvent, BaseDragEndEvent, BaseDragEnterEvent, BaseDragLeaveEvent, BaseDragOverEvent, BaseDragStartEvent, BaseDropEvent, BaseHoverEvent, BaseKeydownEvent, BaseKeypressEvent, BaseKeyupEvent, BaseMousedownEvent, BaseMousemoveEvent, BaseMouseupEvent, BaseScrollEvent, BaseTextChangeEvent, BaseTextInputEvent, Step, BaseStepEvent, BaseLoadEvent, BaseResizeEvent, BaseDragEvent } from '../types';
+export interface MatcherContext<TStepEvent extends BaseStepEvent = BaseStepEvent> {
+    currentStep?: MatcherStep<TStepEvent>;
+    previousStep?: MatcherStep<TStepEvent>;
 }
 export interface MatcherSchema extends StateSchema {
     states: {
@@ -25,142 +25,150 @@ export interface MatcherSchema extends StateSchema {
 }
 export declare type MatcherEvent = {
     type: 'mousedown';
-    data: MousedownEvent;
+    data: BaseMousedownEvent;
     target: MatcherElement | null;
 } | {
     type: 'mouseup';
-    data: MouseupEvent;
+    data: BaseMouseupEvent;
     target: MatcherElement | null;
 } | {
     type: 'click';
-    data: ClickEvent;
+    data: BaseClickEvent;
     target: MatcherElement | null;
 } | {
     type: 'dblclick';
-    data: DblClickEvent;
+    data: BaseDblClickEvent;
     target: MatcherElement | null;
 } | {
     type: 'auxclick';
-    data: AuxClickEvent;
+    data: BaseAuxClickEvent;
     target: MatcherElement | null;
 } | {
     type: 'mousemove';
-    data: MousemoveEvent;
+    data: BaseMousemoveEvent;
     target: MatcherElement | null;
 } | {
     type: 'scroll';
-    data: ScrollEvent;
+    data: BaseScrollEvent;
     target: MatcherElement | null;
 } | {
     type: 'keydown';
-    data: KeydownEvent;
+    data: BaseKeydownEvent;
     target: MatcherElement | null;
 } | {
     type: 'keypress';
-    data: KeypressEvent;
+    data: BaseKeypressEvent;
     target: MatcherElement | null;
 } | {
     type: 'keyup';
-    data: KeyupEvent;
+    data: BaseKeyupEvent;
     target: MatcherElement | null;
 } | {
     type: 'text_input';
-    data: TextInputEvent;
+    data: BaseTextInputEvent;
     target: MatcherElement | null;
 } | {
     type: 'text_change';
-    data: TextChangeEvent;
+    data: BaseTextChangeEvent;
     target: MatcherElement | null;
 } | {
     type: 'blur';
-    data: BlurEvent;
+    data: BaseBlurEvent;
+    target: MatcherElement | null;
+} | {
+    type: 'load';
+    data: BaseLoadEvent;
     target: MatcherElement | null;
 } | {
     type: 'before_unload';
-    data: MachineBeforeUnloadEvent;
+    data: BaseBeforeUnloadEvent;
     target: MatcherElement | null;
 } | {
     type: 'hover';
-    data: HoverEvent;
+    data: BaseHoverEvent;
     target: MatcherElement | null;
 } | {
     type: 'wheel';
-    data: MachineWheelEvent;
+    data: BaseWheelEvent;
     target: MatcherElement | null;
 } | {
     type: 'drag';
-    data: DraggingEvent;
+    data: BaseDragEvent;
     target: MatcherElement | null;
 } | {
     type: 'dragstart';
-    data: DragStartEvent;
+    data: BaseDragStartEvent<unknown>;
     target: MatcherElement | null;
 } | {
     type: 'dragend';
-    data: DragEndEvent;
+    data: BaseDragEndEvent;
     target: MatcherElement | null;
 } | {
     type: 'dragenter';
-    data: DragEnterEvent;
+    data: BaseDragEnterEvent;
     target: MatcherElement | null;
 } | {
     type: 'dragover';
-    data: DragOverEvent;
+    data: BaseDragOverEvent;
     target: MatcherElement | null;
 } | {
     type: 'dragleave';
-    data: DragLeaveEvent;
+    data: BaseDragLeaveEvent;
     target: MatcherElement | null;
 } | {
     type: 'drop';
-    data: DropEvent;
+    data: BaseDropEvent<unknown>;
     target: MatcherElement | null;
 } | {
     type: 'file';
-    data: BrowseFileEvent;
+    data: BaseBrowseFileEvent<unknown>;
+    target: MatcherElement | null;
+} | {
+    type: 'resize';
+    data: BaseResizeEvent;
     target: MatcherElement | null;
 };
-export declare type MatcherState = {
+export declare type MatcherState<TStepEvent extends BaseStepEvent = BaseStepEvent> = {
     value: 'INIT';
-    context: MatcherContext;
+    context: MatcherContext<TStepEvent>;
 } | {
     value: 'CLICK';
-    context: MatcherContext;
+    context: MatcherContext<TStepEvent>;
 } | {
     value: 'RIGHT_CLICK';
-    context: MatcherContext;
+    context: MatcherContext<TStepEvent>;
 } | {
     value: 'DBLCLICK';
-    context: MatcherContext;
+    context: MatcherContext<TStepEvent>;
 } | {
     value: 'DRAG';
-    context: MatcherContext;
+    context: MatcherContext<TStepEvent>;
 } | {
     value: 'KEYPRESS';
-    context: MatcherContext;
+    context: MatcherContext<TStepEvent>;
 } | {
     value: 'TEXT';
-    context: MatcherContext;
+    context: MatcherContext<TStepEvent>;
 } | {
     value: 'BROWSE_FILE';
-    context: MatcherContext;
+    context: MatcherContext<TStepEvent>;
 } | {
     value: 'NAVIGATION';
-    context: MatcherContext;
+    context: MatcherContext<TStepEvent>;
 } | {
     value: 'SCROLL';
-    context: MatcherContext;
+    context: MatcherContext<TStepEvent>;
 } | {
     value: 'REFRESH';
-    context: MatcherContext;
+    context: MatcherContext<TStepEvent>;
 } | {
     value: 'RESIZE';
-    context: MatcherContext;
+    context: MatcherContext<TStepEvent>;
 } | {
     value: 'UNKNOWN';
-    context: MatcherContext;
+    context: MatcherContext<TStepEvent>;
 };
-export declare type MatcherStep = Omit<Step, 'selector'> & {
+export declare type MatcherStep<TStepEvent extends BaseStepEvent = BaseStepEvent> = Omit<Step<TStepEvent>, 'selector'> & {
     target: MatcherElement | null;
     secondary_target: MatcherElement[];
 };
@@ -169,9 +177,9 @@ export declare type MatcherElement = {
     tagName: string;
     attributes: Record<string, string>;
 };
-export declare type MachineMatcherInput = {
+export declare type MachineMatcherInput<TStepEvent extends BaseStepEvent> = {
     element: MatcherElement | null;
-    event: StepEvent;
+    event: TStepEvent;
 };
 export declare type emitType = 'new' | 'end' | 'update';
-export declare type emitFn = (type: emitType, step: MatcherStep) => void;
+export declare type emitFn<TStepEvent extends BaseStepEvent> = (type: emitType, step: MatcherStep<TStepEvent>) => void;

--- a/typings/observer/abstractObserver.d.ts
+++ b/typings/observer/abstractObserver.d.ts
@@ -1,0 +1,18 @@
+import { ThrottleManager } from '../util/throttler';
+import { EventEmitter2 } from 'eventemitter2';
+import { EventProcessor, IObserver, ObserverListener } from './type';
+export declare abstract class AbstractObserver<TEvent, TOutput> implements IObserver<TOutput> {
+    abstract name: string;
+    abstract emitter: EventEmitter2;
+    abstract start(): void;
+    abstract stop(): void;
+    abstract suspend(): void;
+    private static throttleManager;
+    protected preprocess: EventProcessor<TEvent, TOutput>;
+    protected getThrottler: typeof ThrottleManager.prototype.getThrottle;
+    protected invokeAll: typeof ThrottleManager.prototype.invokeAll;
+    constructor(preprocess: EventProcessor<TEvent, TOutput>);
+    protected onEmit(event: TEvent, args: any[], fromThrottler?: boolean): void;
+    on(listener: ObserverListener<TOutput>): ObserverListener<TOutput>;
+    off(listener: ObserverListener<TOutput>): void;
+}

--- a/typings/observer/eventObserver.d.ts
+++ b/typings/observer/eventObserver.d.ts
@@ -1,0 +1,27 @@
+import { EventEmitter2 } from 'eventemitter2';
+import { AbstractObserver } from './abstractObserver';
+import { EventObserverStepEvent, EventProcessor } from './type';
+export declare class EventObserver<TOutput> extends AbstractObserver<EventObserverStepEvent, TOutput> {
+    name: string;
+    emitter: EventEmitter2;
+    private win;
+    private handlers;
+    private state;
+    private previousDragOverTarget;
+    constructor(win: Window, preprocess: EventProcessor<EventObserverStepEvent, TOutput>);
+    start(): void;
+    suspend(): void;
+    stop(): void;
+    private observeMouseInteractions;
+    private observeMousemove;
+    private observeScroll;
+    private observeKeyboardInteractions;
+    private observeTextInput;
+    private observeBlur;
+    private observeBeforeUnload;
+    private observeWheel;
+    private observerDrag;
+    private observeFileInput;
+    private get now();
+    private get active();
+}

--- a/typings/observer/index.d.ts
+++ b/typings/observer/index.d.ts
@@ -1,0 +1,3 @@
+export * from './abstractObserver';
+export * from './eventObserver';
+export * from './type';

--- a/typings/observer/type.d.ts
+++ b/typings/observer/type.d.ts
@@ -1,0 +1,80 @@
+import { EventEmitter2 } from 'eventemitter2';
+import { BaseBlurEvent, BaseClickEvent, BaseDblClickEvent, BaseDragEvent, BaseKeydownEvent, BaseMousemoveEvent, BaseTextChangeEvent, BaseTextInputEvent, BaseWheelEvent, BaseAuxClickEvent, BaseBeforeUnloadEvent, BaseDragStartEvent, BaseHoverEvent, BaseKeyboardEvent, BaseKeyupEvent, BaseLoadEvent, BaseMousedownEvent, BaseMouseupEvent, BaseScrollEvent, BaseBrowseFileEvent, BaseDragEndEvent, BaseDragEnterEvent, BaseDragLeaveEvent, BaseDragOverEvent, BaseDropEvent, BaseResizeEvent, Modifiers } from '../types';
+interface ExtraMouseEventInit {
+    screenX: number;
+    screenY: number;
+    clientX: number;
+    clientY: number;
+    modifiers: Modifiers;
+}
+export interface ObserverMousedownEvent extends BaseMousedownEvent, ExtraMouseEventInit {
+}
+export interface ObserverMouseupEvent extends BaseMouseupEvent, ExtraMouseEventInit {
+}
+export interface ObserverClickEvent extends BaseClickEvent, ExtraMouseEventInit {
+}
+export interface ObserverDblClickEvent extends BaseDblClickEvent, ExtraMouseEventInit {
+}
+export interface ObserverAuxClickEvent extends BaseAuxClickEvent, ExtraMouseEventInit {
+}
+export declare type ObserverMousemoveEvent = BaseMousemoveEvent;
+export declare type ObserverScrollEvent = BaseScrollEvent;
+interface ExtraKeyboardEventInit {
+    code: string;
+    keyCode: number;
+    modifiers: Modifiers;
+}
+export interface ObserverKeydownEvent extends BaseKeydownEvent, ExtraKeyboardEventInit {
+}
+export interface ObserverKeypressEvent extends BaseKeyboardEvent, ExtraKeyboardEventInit {
+}
+export interface ObserverKeyupEvent extends BaseKeyupEvent, ExtraKeyboardEventInit {
+}
+export declare type ObserverTextInputEvent = BaseTextInputEvent;
+export declare type ObserverTextChangeEvent = BaseTextChangeEvent;
+export declare type ObserverLoadEvent = BaseLoadEvent;
+export declare type ObserverBeforeUnloadEvent = BaseBeforeUnloadEvent;
+export declare type ObserverBlurEvent = BaseBlurEvent;
+export declare type ObserverHoverEvent = BaseHoverEvent;
+interface ExtraWheelEventInit {
+    deltaMode?: number;
+    deltaX?: number;
+    deltaY?: number;
+    deltaZ?: number;
+}
+export interface ObserverWheelEvent extends ExtraWheelEventInit, BaseWheelEvent {
+}
+export interface ObserverDragEvent extends BaseDragEvent, ExtraMouseEventInit {
+}
+export interface ObserverDragStartEvent extends BaseDragStartEvent<File>, ExtraMouseEventInit {
+}
+export interface ObserverDragEndEvent extends BaseDragEndEvent, ExtraMouseEventInit {
+}
+export interface ObserverDragEnterEvent extends BaseDragEnterEvent, ExtraMouseEventInit {
+}
+export interface ObserverDragOverEvent extends BaseDragOverEvent, ExtraMouseEventInit {
+}
+export interface ObserverDragLeaveEvent extends BaseDragLeaveEvent, ExtraMouseEventInit {
+}
+export interface ObserverDropEvent extends BaseDropEvent<File>, ExtraMouseEventInit {
+}
+export declare type ObserverBrowseFileEvent = BaseBrowseFileEvent<File>;
+export declare type ObserverResizeEvent = BaseResizeEvent;
+export declare type EventObserverStepEvent = ObserverMousedownEvent | ObserverMouseupEvent | ObserverClickEvent | ObserverAuxClickEvent | ObserverDblClickEvent | ObserverMousemoveEvent | ObserverScrollEvent | ObserverKeydownEvent | ObserverKeypressEvent | ObserverKeyupEvent | ObserverTextInputEvent | ObserverTextChangeEvent | ObserverBlurEvent | ObserverLoadEvent | ObserverBeforeUnloadEvent | ObserverHoverEvent | ObserverWheelEvent | ObserverDragEvent | ObserverDragStartEvent | ObserverDragEndEvent | ObserverDragEnterEvent | ObserverDragOverEvent | ObserverDragLeaveEvent | ObserverDropEvent | ObserverBrowseFileEvent | ObserverResizeEvent;
+declare global {
+    interface UIEvent {
+        path: Array<HTMLElement>;
+    }
+}
+export interface IObserver<TOutput> {
+    name: string;
+    emitter: EventEmitter2;
+    start(): void;
+    stop(): void;
+    suspend(): void;
+    on(listenerFn: ObserverListener<TOutput>): ObserverListener<TOutput>;
+    off(listenerFn: ObserverListener<TOutput>): void;
+}
+export declare type ObserverListener<TOutput> = (output: TOutput) => void;
+export declare type EventProcessor<TEvent, TOutput> = (event: TEvent, ...args: any[]) => TOutput;
+export {};

--- a/typings/recorder/index.d.ts
+++ b/typings/recorder/index.d.ts
@@ -1,0 +1,18 @@
+import { IMatcher } from '../matcher';
+import { AbstractObserver } from '../observer';
+export declare type RecorderOptions<TMiddleware> = {
+    matcher: IMatcher<TMiddleware>;
+};
+export declare class Recorder<TEvent, TMiddleware> {
+    private observersList;
+    private listenerMap;
+    private matcher;
+    private _state;
+    get state(): 'active' | 'inactive' | 'suspend';
+    constructor(options: RecorderOptions<TMiddleware>);
+    start(): void;
+    suspend(): void;
+    stop(): void;
+    extendObserver(observer: AbstractObserver<TEvent, TMiddleware>): AbstractObserver<TEvent, TMiddleware>;
+    removeObserver(observer: AbstractObserver<TEvent, TMiddleware>): void;
+}

--- a/typings/types.d.ts
+++ b/typings/types.d.ts
@@ -6,12 +6,12 @@ export declare enum MatcherKey {
     EMIT_UPDATE_STEP = "matcher.step_event.update",
     EMIT_END_STEP = "matcher.step_event.end"
 }
-export declare type Step = {
+export declare type Step<TEvent extends BaseStepEvent> = {
     selector: IMeta;
     type: 'CLICK' | 'RIGHT_CLICK' | 'DBLCLICK' | 'DRAG' | 'KEYPRESS' | 'TEXT' | 'BROWSE_FILE' | 'DROP_FILE' | 'NAVIGATION' | 'SCROLL' | 'REFRESH' | 'RESIZE' | 'HOVER' | 'UNKNOWN';
-    events: StepEvent[];
+    events: TEvent[];
 };
-export declare type StepEvent = MouseEvents | ScrollEvent | KeydownEvent | KeypressEvent | TextInputEvent | TextChangeEvent | KeyupEvent | BlurEvent | MachineBeforeUnloadEvent | HoverEvent | MachineWheelEvent | DraggingEvent | DropEvent | DragStartEvent | DragEndEvent | DragEnterEvent | DragOverEvent | DragLeaveEvent | BrowseFileEvent;
+export declare type BaseStepEvent = BaseMousedownEvent | BaseMouseupEvent | BaseClickEvent | BaseAuxClickEvent | BaseDblClickEvent | BaseMousemoveEvent | BaseScrollEvent | BaseKeydownEvent | BaseKeypressEvent | BaseKeyupEvent | BaseTextInputEvent | BaseTextChangeEvent | BaseBlurEvent | BaseLoadEvent | BaseBeforeUnloadEvent | BaseHoverEvent | BaseWheelEvent | BaseDragEvent | BaseDropEvent<unknown> | BaseDragStartEvent<unknown> | BaseDragEndEvent | BaseDragEnterEvent | BaseDragOverEvent | BaseDragLeaveEvent | BaseBrowseFileEvent<unknown> | BaseResizeEvent;
 export declare type Modifiers = {
     ctrlKey?: true;
     altKey?: true;
@@ -25,113 +25,120 @@ export declare type MousemoveRecord = {
     screenY: number;
     timeOffset: number;
 };
-declare type BaseEvent = {
+interface BaseEvent {
+    type: 'mousedown' | 'mouseup' | 'mousemove' | 'click' | 'dblclick' | 'auxclick' | 'scroll' | 'keydown' | 'keypress' | 'keyup' | 'text_input' | 'text_change' | 'load' | 'before_unload' | 'blur' | 'hover' | 'wheel' | 'drag' | 'dragstart' | 'dragend' | 'dragenter' | 'dragover' | 'dragleave' | 'drop' | 'file' | 'resize';
     timestamp: number;
-};
-export declare type MachineMouseEvent = BaseEvent & {
-    screenX: number;
-    screenY: number;
-    clientX: number;
-    clientY: number;
+}
+export interface BaseMouseEvent extends BaseEvent {
+    type: 'mousedown' | 'mouseup' | 'click' | 'dblclick' | 'auxclick' | 'drag' | 'drop' | 'dragstart' | 'dragend' | 'dragenter' | 'dragover' | 'dragleave';
     button: number;
     buttons: number;
-    modifiers: Modifiers;
-};
-export declare type MousedownEvent = MachineMouseEvent & {
+    clientX: number;
+    clientY: number;
+}
+export interface BaseMousedownEvent extends BaseMouseEvent {
     type: 'mousedown';
-};
-export declare type MouseupEvent = MachineMouseEvent & {
+}
+export interface BaseMouseupEvent extends BaseMouseEvent {
     type: 'mouseup';
-};
-export declare type ClickEvent = MachineMouseEvent & {
+}
+export interface BaseClickEvent extends BaseMouseEvent {
     type: 'click';
-};
-export declare type DblClickEvent = MachineMouseEvent & {
+}
+export interface BaseDblClickEvent extends BaseMouseEvent {
     type: 'dblclick';
-};
-export declare type AuxClickEvent = MachineMouseEvent & {
+}
+export interface BaseAuxClickEvent extends BaseMouseEvent {
     type: 'auxclick';
-};
-export declare type MousemoveEvent = BaseEvent & {
+}
+export interface BaseMousemoveEvent extends BaseEvent {
     type: 'mousemove';
     positions: Array<MousemoveRecord>;
-};
-declare type MouseEvents = MousedownEvent | MouseupEvent | ClickEvent | DblClickEvent | AuxClickEvent | MousemoveEvent;
-export declare type ScrollEvent = BaseEvent & {
+}
+export interface BaseScrollEvent extends BaseEvent {
     type: 'scroll';
     scrollLeft: number;
     scrollTop: number;
-};
-export declare type MachineKeyboardEvent = BaseEvent & {
+}
+export interface BaseKeyboardEvent extends BaseEvent {
+    type: 'keydown' | 'keypress' | 'keyup';
     key: string;
-    code: string;
-    keyCode: number;
-    modifiers: Modifiers;
-};
-export declare type KeydownEvent = MachineKeyboardEvent & {
+}
+export interface BaseKeydownEvent extends BaseKeyboardEvent {
     type: 'keydown';
-};
-export declare type KeypressEvent = MachineKeyboardEvent & {
+}
+export interface BaseKeypressEvent extends BaseKeyboardEvent {
     type: 'keypress';
-};
-export declare type KeyupEvent = MachineKeyboardEvent & {
+}
+export interface BaseKeyupEvent extends BaseKeyboardEvent {
     type: 'keyup';
-};
-export declare type TextInputEvent = BaseEvent & {
+}
+export interface BaseTextInputEvent extends BaseEvent {
     type: 'text_input';
     data: string;
     value: string;
-};
-export declare type TextChangeEvent = BaseEvent & {
+}
+export interface BaseTextChangeEvent extends BaseEvent {
     type: 'text_change';
     value: string;
-};
-export declare type BlurEvent = BaseEvent & {
-    type: 'blur';
-};
-export declare type MachineBeforeUnloadEvent = BaseEvent & {
+}
+export interface BaseLoadEvent extends BaseEvent {
+    type: 'load';
+    url: string;
+}
+export interface BaseBeforeUnloadEvent extends BaseEvent {
     type: 'before_unload';
-};
-export declare type HoverEvent = BaseEvent & {
+    url: string;
+}
+export interface BaseBlurEvent extends BaseEvent {
+    type: 'blur';
+}
+export interface BaseHoverEvent extends BaseEvent {
     type: 'hover';
     clientX: number;
     clientY: number;
-};
-export declare type MachineWheelEvent = BaseEvent & {
+}
+export interface BaseWheelEvent extends BaseEvent {
     type: 'wheel';
-};
-export declare type MachineDragEvent = MachineMouseEvent & {
+}
+export interface BaseDraggingEvent extends BaseMouseEvent {
+    type: 'drag' | 'dragstart' | 'dragend' | 'dragenter' | 'dragover' | 'dragleave' | 'drop';
     targetIndex: number;
-};
-export declare type DraggingEvent = MachineDragEvent & {
+}
+export interface BaseDragEvent extends BaseDraggingEvent {
     type: 'drag';
-};
-export declare type DragStartEvent = MachineDragEvent & {
+}
+export interface BaseDragStartEvent<TFile> extends BaseDraggingEvent {
     type: 'dragstart';
     effectAllowed: DataTransfer['effectAllowed'];
-    items: Array<IDataTransferItem | undefined>;
-};
-export declare type DragEndEvent = MachineDragEvent & {
+    items: Array<IDataTransferItem<TFile> | undefined>;
+}
+export interface BaseDragEndEvent extends BaseDraggingEvent {
     type: 'dragend';
-};
-export declare type DragEnterEvent = MachineDragEvent & {
+}
+export interface BaseDragEnterEvent extends BaseDraggingEvent {
     type: 'dragenter';
-};
-export declare type DragOverEvent = MachineDragEvent & {
+}
+export interface BaseDragOverEvent extends BaseDraggingEvent {
     type: 'dragover';
     dropEffect: DataTransfer['dropEffect'];
-};
-export declare type DragLeaveEvent = MachineDragEvent & {
+}
+export interface BaseDragLeaveEvent extends BaseDraggingEvent {
     type: 'dragleave';
-};
-export declare type DropEvent = MachineDragEvent & {
+}
+export interface BaseDropEvent<TFile> extends BaseDraggingEvent {
     type: 'drop';
     effectAllowed: DataTransfer['effectAllowed'];
     dropEffect: DataTransfer['dropEffect'];
-    items: Array<IDataTransferItem | undefined>;
-};
-export declare type BrowseFileEvent = BaseEvent & {
+    items: Array<IDataTransferItem<TFile> | undefined>;
+}
+export interface BaseBrowseFileEvent<TFile> extends BaseEvent {
     type: 'file';
-    files: Array<File>;
-};
+    files: Array<TFile>;
+}
+export interface BaseResizeEvent extends BaseEvent {
+    type: 'resize';
+    x: number;
+    y: number;
+}
 export {};

--- a/typings/util/entry-reader.d.ts
+++ b/typings/util/entry-reader.d.ts
@@ -1,17 +1,17 @@
-export interface IDataTransferFileItem {
+export interface IDataTransferFileItem<TFile> {
     kind: 'file';
     path: string;
-    file: File;
+    file: TFile;
 }
-export interface IDataTransferDirectoryItem {
+export interface IDataTransferDirectoryItem<TFile> {
     kind: 'directory';
     path: string;
-    child: Array<IDataTransferFileItem | IDataTransferDirectoryItem | undefined>;
+    child: Array<IDataTransferFileItem<TFile> | IDataTransferDirectoryItem<TFile> | undefined>;
 }
 export interface IDataTransferStringItem {
     kind: 'string';
     data: string;
     type: string;
 }
-export declare type IDataTransferItem = IDataTransferFileItem | IDataTransferDirectoryItem | IDataTransferStringItem;
-export declare const getSerializedDataTransferItemList: (dt: DataTransfer | null) => Promise<Array<IDataTransferItem | undefined>>;
+export declare type IDataTransferItem<TFile> = IDataTransferFileItem<TFile> | IDataTransferDirectoryItem<TFile> | IDataTransferStringItem;
+export declare const getSerializedDataTransferItemList: (dt: DataTransfer | null) => Promise<Array<IDataTransferItem<File> | undefined>>;


### PR DESCRIPTION
1. make matcher and observer use different type inherited from a same interface.
2. make matcher accept a generic which will infer the event type output by matcher. (matcher itself use the base interface)